### PR TITLE
Ensure point is on the process mark after starting R

### DIFF
--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -574,7 +574,8 @@ will be prompted to enter arguments interactively."
           ;; trigger the callback
           (process-send-string (get-process ess-local-process-name) "\n"))
       (ess-wait-for-process)
-      (R-initialize-on-start))
+      (R-initialize-on-start)
+      (comint-goto-process-mark))
 
     (ess-write-to-dribble-buffer
      (format "(R): inferior-ess-language-start=%s\n"


### PR DESCRIPTION
Without this, M-x R leaves the mark behind the prompt:

```
|>
```

rather than 

```
>|
```

I only see that issue starting R from M-x R, not when starting it from a script file. Dunno why, but this fixes it either way.